### PR TITLE
feat(utils): This feature creates the reg client using the oci-client crate

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,11 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.95"
 clap = "4.5.29"
+merkle_hash = "3.7.0"
+oci-client = "0.14.0"
 serde_json = "1.0.138"
 serde = { version = "1.0.217", features = ["derive"] }
 rayon = "1.10.0"
-merkle_hash = "3.7.0"
+tokio = "1.43.0"
 
 [dev-dependencies]
 tempfile = "3.16.0"

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -21,5 +21,6 @@ mod hash_watch_directories;
 mod hash_watch_files;
 
 mod os_open;
-
 pub use os_open::*;
+
+mod build_log;

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -24,3 +24,5 @@ mod os_open;
 pub use os_open::*;
 
 mod build_log;
+pub use build_log::*;
+mod create_regclient_client;

--- a/cli/src/utils/build_log.rs
+++ b/cli/src/utils/build_log.rs
@@ -1,0 +1,16 @@
+/// This struct is used to save the process of the build and any variables as well.
+/// It is used in testing to ensure that the expected outcomes are met.
+#[derive(Debug, Default)]
+pub struct BuildLog {
+    pub custom_dockerfile: bool,
+    pub custom_host: bool,
+    pub docker_password: String,
+    pub docker_registry: String,
+    pub docker_username: String,
+    pub hash_exists: bool,
+    pub hashed_image_name: String,
+    pub image_hash: String,
+    pub local_tag: String,
+    pub output_tags: Vec<String>,
+    pub version: String,
+}

--- a/cli/src/utils/create_regclient_client.rs
+++ b/cli/src/utils/create_regclient_client.rs
@@ -1,0 +1,92 @@
+use crate::utils::build_log::BuildLog;
+use anyhow::Result;
+use oci_client::client::{Client, ClientConfig, ClientProtocol};
+use oci_client::secrets::RegistryAuth;
+use oci_client::{Reference, RegistryOperation};
+use std::error::Error;
+use std::str::FromStr;
+
+/// Creates an OCI distribution client and authenticates with the specified registry.
+///
+/// # Arguments
+/// * `registry` - The registry URL. E.g <AWS_ACCOUNT_ID>.dkr.ecr.eu-west-1.amazonaws.com
+/// * `username` - The username for authentication.
+/// * `password` - The password for authentication.
+/// * `docker_image_name` - The name of the image in the registry in this format `org/image-name:hash`
+/// * `build_log` - A mutable reference to the `BuildLog` struct to record the build state.
+///
+/// # Returns
+/// * `Result<Client, Box<dyn Error>>` containing the initialized and authenticated client that can pull and push images or an error if it fails.
+pub async fn create_regclient_client(
+    registry: &str,
+    username: &str,
+    password: &str,
+    docker_image_name: &str,
+    build_log: &mut BuildLog,
+) -> Result<Client, Box<dyn Error>> {
+    let mut custom_host = false;
+
+    if !registry.is_empty() {
+        build_log.docker_registry = registry.to_string();
+        custom_host = true;
+    }
+
+    if !username.is_empty() {
+        build_log.docker_username = username.to_string();
+        custom_host = true;
+    }
+
+    if !password.is_empty() {
+        build_log.docker_password = password.to_string();
+        custom_host = true;
+    }
+
+    if custom_host && registry.is_empty() {
+        // Use Docker default registry if only authentication details are provided
+        build_log.docker_registry = "index.docker.io".to_string();
+    }
+
+    build_log.custom_host = custom_host;
+
+    // Determine authentication method
+    let registry_auth = if custom_host && !password.is_empty() {
+        RegistryAuth::Basic(username.to_string(), password.to_string())
+    } else {
+        RegistryAuth::Anonymous
+    };
+
+    let client_config = ClientConfig {
+        protocol: ClientProtocol::Https,
+        ..Default::default()
+    };
+
+    let client = Client::new(client_config);
+
+    // Attempt authentication with the registry
+    // Construct a reference to an image in the registry
+    let reference = Reference::from_str(&docker_image_name)?;
+
+    // Authenticate to ensure the client is ready for use
+    client
+        .auth(&reference, &registry_auth, RegistryOperation::Pull)
+        .await
+        .map_err(|err| {
+            eprintln!(
+                "ERROR: Failed to authenticate with registry for pull operation: '{}': {}",
+                build_log.docker_registry, err
+            );
+            err
+        })?;
+
+    client
+        .auth(&reference, &registry_auth, RegistryOperation::Push)
+        .await
+        .map_err(|err| {
+            eprintln!(
+                "ERROR: Failed to authenticate with registry for push operation: '{}': {}",
+                build_log.docker_registry, err
+            );
+            err
+        })?;
+    Ok(client)
+}


### PR DESCRIPTION
### Type of change

<!-- Please uncomment the relevant option. -->

<!-- - [ ] 🐛 Bug fix (non-breaking change which fixes an issue) -->
- [X] ✨ New feature (non-breaking change which adds functionality)
<!-- - [ ] 🛠️ Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - [ ] 📝 Documentation changes or updates -->

### Completed

<!-- ✅  Please include a summary of the changes and the related issue. -->
* Installed `tokio`
* Installed `anyhow` for now. I will change to use custom errors later on.
* Added the functionality to create an authenticated registry client.

### Screenshots (Optional)

<!-- 📷 Add any relevant screenshots or screen recordings here  -->

None.

### Additional Info
None.
<!-- You can uncomment one option if required. -->
<!-- - [ ] Devops related work -->
