### PR TITLE
feat(utils): This feature adds a check manifest head util that can determine if an image tag already exists in a repository

### DIFF
--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -24,6 +24,7 @@ mod os_open;
 pub use os_open::*;
 
 mod build_log;
+mod check_manifest_head;
 mod create_docker_client;
 mod create_regclient_client;
 mod docker_config_loader;

--- a/cli/src/utils/check_manifest_head.rs
+++ b/cli/src/utils/check_manifest_head.rs
@@ -1,0 +1,44 @@
+use oci_client::errors::OciDistributionError;
+use oci_client::secrets::RegistryAuth;
+use oci_client::{Client as RegistryClient, Reference};
+use std::any::Any;
+
+/// Checks if the registry contains an image with the tag specified. If the manifest check fails it
+/// will return false. Otherwise, it will return true to indicate that the image does exist with the
+/// tag given.
+///
+/// # Arguments
+/// * `tag` - The image tag to check for.
+/// * `reference` - An object containing details about the image repository and registry to perform
+/// the check in.
+/// * `registry_client` The authenticated OCI registry client to connect and check the registry with
+///
+/// # Returns
+/// * `bool` A true or false flag indicating whether the tag already exists in the image repository.
+///
+pub async fn check_manifest_head(
+    tag: &str,
+    reference: Reference,
+    registry_client: RegistryClient,
+) -> bool {
+    println!("Checking for the image hash {} on the registry.", tag);
+    // Use anonymous here because the client should already be authenticated.
+    return match registry_client
+        .pull_image_manifest(&reference, &RegistryAuth::Anonymous)
+        .await
+    {
+        Ok(manifest) => true,
+        Err(error) => {
+            eprintln!(
+                "The image hash {} does not exist on the registry or we were unable to pull it.",
+                tag
+            );
+            if error.type_id() == OciDistributionError::AuthenticationFailure.type_id() {
+                println!("WARN: Unable to pull the details from the registry, please ensure you have the correct credentials.");
+                println!("WARN: The build will continue, but this should investigated.");
+            }
+            eprintln!("{}", error);
+            false
+        }
+    };
+}

--- a/cli/src/utils/create_regclient_client.rs
+++ b/cli/src/utils/create_regclient_client.rs
@@ -16,14 +16,14 @@ use std::str::FromStr;
 /// * `build_log` - A mutable reference to the `BuildLog` struct to record the build state.
 ///
 /// # Returns
-/// * `Result<Client, Box<dyn Error>>` containing the initialized and authenticated client that can pull and push images or an error if it fails.
+/// * `Result<(Client, Reference), Box<dyn Error>>` containing the initialized and authenticated client that can pull and push images or an error if it fails.
 pub async fn create_regclient_client(
     registry: &str,
     username: &str,
     password: &str,
     docker_image_name: &str,
     build_log: &mut BuildLog,
-) -> Result<Client, Box<dyn Error>> {
+) -> Result<(Client, Reference), Box<dyn Error>> {
     let mut custom_host = false;
 
     if !registry.is_empty() {
@@ -88,5 +88,5 @@ pub async fn create_regclient_client(
             );
             err
         })?;
-    Ok(client)
+    Ok((client, reference))
 }


### PR DESCRIPTION
### Type of change

<!-- Please uncomment the relevant option. -->

<!-- - [ ] 🐛 Bug fix (non-breaking change which fixes an issue) -->
- [x] ✨ New feature (non-breaking change which adds functionality)
<!-- - [ ] 🛠️ Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - [ ] 📝 Documentation changes or updates -->

### Completed

<!-- ✅  Please include a summary of the changes and the related issue. -->
* Updated `create_regclient_client` to return the reference object that contains the image repository in it.
* Created `check_manifest_head` that can determine if an image tag already exists on the repository specified.

### Screenshots (Optional)

<!-- 📷 Add any relevant screenshots or screen recordings here  -->

None.

### Additional Info
None.

<!-- You can uncomment one option if required. -->
<!-- - [ ] Devops related work -->
