### PR TITLE
fix(devops-build): fix CI build workflow and add artifact uploads

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,33 +16,50 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            os_name: linux
+            arch: aarch64
+          - target: x86_64-unknown-linux-gnu
+            os_name: linux
+            arch: x86_64
+          - target: x86_64-pc-windows-gnu
+            os_name: windows
+            arch: x86_64
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install Task
-        uses: arduino/setup-task@v2
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
 
       - name: Install cross
         uses: taiki-e/install-action@cross
 
-      - name: Build the binaries for each supported platform
-        run: task build
+      - name: Get version from Cargo.toml
+        id: version
+        run: echo "version=$(grep '^version' cli/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')" >> "$GITHUB_OUTPUT"
 
-      - name: Upload build artifacts
+      - name: Build for ${{ matrix.target }}
+        working-directory: cli
+        run: cross build --release --target ${{ matrix.target }} --bin dockem-rs
+
+      - name: Prepare artifact
+        run: |
+          mkdir -p release
+          version="v${{ steps.version.outputs.version }}"
+          artifact="dockem-rs-${version}-${{ matrix.os_name }}-${{ matrix.arch }}"
+          if [ "${{ matrix.os_name }}" = "windows" ]; then
+            mv "cli/target/${{ matrix.target }}/release/dockem-rs.exe" "release/${artifact}.exe"
+          else
+            mv "cli/target/${{ matrix.target }}/release/dockem-rs" "release/${artifact}"
+          fi
+
+      - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: release-binaries
+          name: dockem-rs-${{ matrix.os_name }}-${{ matrix.arch }}
           path: release/
           if-no-files-found: error

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,10 @@ on:
       - main
       - develop
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-unix:
     runs-on: ubuntu-latest
@@ -39,6 +43,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v2
 
       - name: Install cargo-zigbuild
         uses: taiki-e/install-action@cargo-zigbuild

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ on:
       - develop
 
 jobs:
-  build-linux:
+  build-unix:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -26,14 +26,22 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os_name: linux
             arch: x86_64
+          - target: aarch64-apple-darwin
+            os_name: macos
+            arch: aarch64
+          - target: x86_64-apple-darwin
+            os_name: macos
+            arch: x86_64
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
-      - name: Install cross
-        uses: taiki-e/install-action@cross
+      - name: Install cargo-zigbuild
+        uses: taiki-e/install-action@cargo-zigbuild
 
       - name: Get version from Cargo.toml
         id: version
@@ -41,7 +49,7 @@ jobs:
 
       - name: Build for ${{ matrix.target }}
         working-directory: cli
-        run: cross build --release --target ${{ matrix.target }} --bin dockem-rs
+        run: cargo zigbuild --release --target ${{ matrix.target }} --bin dockem-rs
 
       - name: Prepare artifact
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ on:
       - develop
 
 jobs:
-  build:
+  build-linux:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -25,9 +25,6 @@ jobs:
             arch: aarch64
           - target: x86_64-unknown-linux-gnu
             os_name: linux
-            arch: x86_64
-          - target: x86_64-pc-windows-gnu
-            os_name: windows
             arch: x86_64
     steps:
       - uses: actions/checkout@v4
@@ -50,16 +47,43 @@ jobs:
         run: |
           mkdir -p release
           version="v${{ steps.version.outputs.version }}"
-          artifact="dockem-rs-${version}-${{ matrix.os_name }}-${{ matrix.arch }}"
-          if [ "${{ matrix.os_name }}" = "windows" ]; then
-            mv "cli/target/${{ matrix.target }}/release/dockem-rs.exe" "release/${artifact}.exe"
-          else
-            mv "cli/target/${{ matrix.target }}/release/dockem-rs" "release/${artifact}"
-          fi
+          mv "cli/target/${{ matrix.target }}/release/dockem-rs" "release/dockem-rs-${version}-${{ matrix.os_name }}-${{ matrix.arch }}"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: dockem-rs-${{ matrix.os_name }}-${{ matrix.arch }}
+          path: release/
+          if-no-files-found: error
+
+  build-windows:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Get version from Cargo.toml
+        id: version
+        shell: bash
+        run: echo "version=$(grep '^version' cli/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')" >> "$GITHUB_OUTPUT"
+
+      - name: Build for Windows
+        working-directory: cli
+        run: cargo build --release --bin dockem-rs
+
+      - name: Prepare artifact
+        shell: bash
+        run: |
+          mkdir -p release
+          version="v${{ steps.version.outputs.version }}"
+          mv "cli/target/release/dockem-rs.exe" "release/dockem-rs-${version}-windows-x86_64.exe"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dockem-rs-windows-x86_64
           path: release/
           if-no-files-found: error

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-unix:
+  build-linux:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -30,25 +30,14 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os_name: linux
             arch: x86_64
-          - target: aarch64-apple-darwin
-            os_name: macos
-            arch: aarch64
-          - target: x86_64-apple-darwin
-            os_name: macos
-            arch: x86_64
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
 
-      - name: Set up Zig
-        uses: mlugg/setup-zig@v2
-
-      - name: Install cargo-zigbuild
-        uses: taiki-e/install-action@cargo-zigbuild
+      - name: Install cross
+        uses: taiki-e/install-action@cross
 
       - name: Get version from Cargo.toml
         id: version
@@ -56,7 +45,7 @@ jobs:
 
       - name: Build for ${{ matrix.target }}
         working-directory: cli
-        run: cargo zigbuild --release --target ${{ matrix.target }} --bin dockem-rs
+        run: cross build --release --target ${{ matrix.target }} --bin dockem-rs
 
       - name: Prepare artifact
         run: |

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -10,6 +10,10 @@ on:
       - main
       - develop
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ There are a few tweaks and features I'd like to implement to improve the overall
   refactoring and feature development
 - [ ] Test that the CLI can read docker `config.json` files on a server if docker username
   and password are not given.
-- [ ] Setup a Custom GitHub runner that can build the Darwin (macOS) versions. Steps to do
+- [x] Setup a Custom GitHub runner that can build the Darwin (macOS) versions. Steps to do
   so can be found in
   this [article](https://blog.crafteo.io/2024/02/29/my-rust-cross-compilation-journey/).
 - [ ] Add a Homebrew tap
@@ -290,8 +290,6 @@ task build
 
 * Linux x86_64 / Linux amd64
 * Linux aarch64 / Linux arm64
-* Windows
-
-I wanted to support Darwin (macOS) Targets, but it seemed like too much effort for now.
-Maybe in a future release I will work on figuring it out by following
-this [article](https://blog.crafteo.io/2024/02/29/my-rust-cross-compilation-journey/).
+* macOS x86_64 (Intel)
+* macOS aarch64 (Apple Silicon)
+* Windows x86_64

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ There are a few tweaks and features I'd like to implement to improve the overall
   refactoring and feature development
 - [ ] Test that the CLI can read docker `config.json` files on a server if docker username
   and password are not given.
-- [x] Setup a Custom GitHub runner that can build the Darwin (macOS) versions. Steps to do
+- [ ] Setup a Custom GitHub runner that can build the Darwin (macOS) versions. Steps to do
   so can be found in
   this [article](https://blog.crafteo.io/2024/02/29/my-rust-cross-compilation-journey/).
 - [ ] Add a Homebrew tap
@@ -290,6 +290,8 @@ task build
 
 * Linux x86_64 / Linux amd64
 * Linux aarch64 / Linux arm64
-* macOS x86_64 (Intel)
-* macOS aarch64 (Apple Silicon)
-* Windows x86_64
+* Windows
+
+I wanted to support Darwin (macOS) Targets, but it seemed like too much effort for now.
+Maybe in a future release I will work on figuring it out by following
+this [article](https://blog.crafteo.io/2024/02/29/my-rust-cross-compilation-journey/).

--- a/cli/Cross.toml
+++ b/cli/Cross.toml
@@ -1,4 +1,0 @@
-[target.x86_64-pc-windows-gnu]
-pre-build = [
-    "apt-get update && apt-get install -y perl make",
-]

--- a/cli/Cross.toml
+++ b/cli/Cross.toml
@@ -1,14 +1,4 @@
-[target.x86_64-unknown-linux-gnu]
-pre-build = [
-    "apt-get update",
-    "apt-get install -y pkg-config libssl-dev",
-]
-
-[target.aarch64-unknown-linux-gnu]
-pre-build = [
-    "dpkg --add-architecture arm64",
-    "apt-get update",
-    "apt-get install -y libssl-dev:arm64",
-]
-
 [target.x86_64-pc-windows-gnu]
+pre-build = [
+    "apt-get update && apt-get install -y perl make",
+]


### PR DESCRIPTION
### Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Completed

Remove `cli/Cross.toml` pre-build commands that fail on newer cross Docker images.

The `openssl` crate uses the `vendored` feature which compiles OpenSSL from source during the build. The pre-build commands installing system `libssl-dev` are unnecessary and fail on newer cross Docker images (especially the `aarch64` target's `dpkg --add-architecture arm64` + `apt-get install libssl-dev:arm64`).

### Additional Info

- [x] Devops related work