### PR TITLE
chore: add git-flow to session startup hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -30,5 +30,16 @@ fi
 
 cargo clippy --version >/dev/null 2>&1 || rustup component add clippy
 
+cd "$CLAUDE_PROJECT_DIR"
+git rev-parse --verify develop &>/dev/null || git branch develop origin/develop
+git config gitflow.branch.master main
+git config gitflow.branch.develop develop
+git config gitflow.prefix.feature feature/
+git config gitflow.prefix.bugfix bugfix/
+git config gitflow.prefix.release release/
+git config gitflow.prefix.hotfix hotfix/
+git config gitflow.prefix.support support/
+git config gitflow.prefix.versiontag ""
+
 cd "$CLAUDE_PROJECT_DIR/cli"
 cargo build 2>&1

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -13,6 +13,7 @@ apt-get install -y -qq --no-install-recommends \
   perl \
   make \
   xz-utils \
+  git-flow \
   > /dev/null 2>&1
 
 npm install -g @go-task/cli > /dev/null 2>&1


### PR DESCRIPTION
### Type of change

- [x] 🛠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Completed

- [x] Install `git-flow` (AVH Edition 1.12.3) via apt in the Claude Code web session startup hook
- [x] Configure git-flow non-interactively with correct defaults: `main` as production branch, `develop` as integration branch, and standard prefixes (`feature/`, `bugfix/`, `release/`, `hotfix/`, `support/`)
- [x] Use direct `git config` commands instead of `git flow init` to avoid issues with dirty working trees or interactive prompts
- [x] Ensure local `develop` branch exists before configuring git-flow
- [x] Verified hook runs successfully end-to-end
- [x] Verified `git flow version` returns `1.12.3 (AVH Edition)`
- [x] Verified `git config --get-regexp gitflow` shows correct branch and prefix configuration

### Screenshots (Optional)

### Additional Info

- [x] Devops related work

https://claude.ai/code/session_019h9Keydc43xweTRn7y9tGw