### PR TITLE
fix(ci): disable GPG signing in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config commit.gpgsign false
+          git config tag.gpgsign false
 
       - name: Install git-flow
         run: sudo apt-get update -qq && sudo apt-get install -y -qq git-flow


### PR DESCRIPTION
### Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Completed

- Disabled GPG signing for commits and tags in the release workflow (`commit.gpgsign false`, `tag.gpgsign false`)
- Fixes `gpg: skipped "github-actions[bot]": No secret key` error during `entro-version release`

### Screenshots (Optional)

N/A

### Additional Info

- [x] Devops related work

https://claude.ai/code/session_019WZK6wEqTDzneqn4UtKttu

---
_Generated by [Claude Code](https://claude.ai/code/session_019WZK6wEqTDzneqn4UtKttu)_