### PR TITLE
feat(ci): add ci:release tasks with --no-sign for unsigned CI releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,8 +32,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config commit.gpgsign false
-          git config tag.gpgsign false
 
       - name: Install git-flow
         run: sudo apt-get update -qq && sudo apt-get install -y -qq git-flow
@@ -66,9 +64,9 @@ jobs:
       - name: Run release
         run: |
           if [ "${{ inputs.release_type }}" = "major" ]; then
-            task release-major
+            task ci:release-major
           else
-            task release
+            task ci:release
           fi
 
       - name: Push release

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -55,6 +55,26 @@ tasks:
         cd ../
         npx --yes entro-version release --main-branch-name=main --commit-and-tag-version-flag="--release-as=major"
 
+  ci:release:
+    desc: "Run a cargo release in CI without GPG signing"
+    cmds:
+      - |
+        cd cli
+        cargo set-version {{.NEXT_VERSION}}
+        git commit -am "chore(release): update cargo version"
+        cd ../
+        npx --yes entro-version release --main-branch-name=main --no-sign
+
+  ci:release-major:
+    desc: "Run a major release in CI without GPG signing"
+    cmds:
+      - |
+        cd cli
+        cargo set-version {{.NEXT_MAJOR_VERSION}}
+        git commit -am "chore(release): update cargo version"
+        cd ../
+        npx --yes entro-version release --main-branch-name=main --no-sign --commit-and-tag-version-flag="--release-as=major"
+
   build-binary:
     desc: "Build the binary"
     cmds:


### PR DESCRIPTION
### Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)

### Completed

- Added `ci:release` and `ci:release-major` Taskfile tasks that pass `--no-sign` to `entro-version release`
- Updated release workflow to use `ci:release` / `ci:release-major` instead of overriding git gpgsign config
- Keeps local `release` / `release-major` tasks unchanged for signed developer releases

### Screenshots (Optional)

N/A

### Additional Info

- [x] Devops related work

https://claude.ai/code/session_019WZK6wEqTDzneqn4UtKttu

---
_Generated by [Claude Code](https://claude.ai/code/session_019WZK6wEqTDzneqn4UtKttu)_