### PR TITLE
fix(devops-build): add workflow_dispatch trigger for manual tag builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,12 @@ on:
     branches:
       - main
       - develop
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to build (e.g. v1.2.0). Leave empty to build the selected branch."
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,6 +38,8 @@ jobs:
             arch: x86_64
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -65,6 +73,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
### Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)

### Completed

- The build workflow already triggers on `v*` tag pushes
- Added a `workflow_dispatch` trigger with an optional `tag` input so any tag can be re-built manually from the Actions UI or API
- Both `build-linux` and `build-windows` jobs check out the specified tag ref when provided

### Screenshots (Optional)

### Additional Info

- [x] Devops related work